### PR TITLE
Allow to customize index name

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ export K6_ELASTICSEARCH_INSECURE_SKIP_VERIFY=true
 ./k6 run ./examples/script.js -o output-elasticsearch
 ```
 
-The metrics are stored in the index `k6-metrics` which will be automatically created by this extension. See the [mapping](pkg/esoutput/mapping.json) for details.
+The metrics are stored in the index `k6-metrics` by default which will be automatically created by this extension. See the [mapping](pkg/esoutput/mapping.json) for details. The index name can be customized with the environment variable `K6_ELASTICSEARCH_INDEX_NAME`.
 
 ## Docker Compose
 
@@ -105,7 +105,7 @@ Clone the repo to get started and follow these steps:
 
 5. Visit http://localhost:5601/ to view results in Kibana (default credentials are `elastic` / `changeme`).
 
-    - Create a [Data View](https://www.elastic.co/guide/en/kibana/current/data-views.html) for the index `k6-metrics`.
+    - Create a [Data View](https://www.elastic.co/guide/en/kibana/current/data-views.html) for the index `k6-metrics` or the index name in `K6_ELASTICSEARCH_INDEX_NAME` if it is set.
         ![Kibana Data View](./images/kibana-data-view.png)
     - Go to [Discover](https://www.elastic.co/guide/en/kibana/current/discover.html) to start exploring the metrics.
         ![Kibana Discover](./images/kibana-discover.png)

--- a/pkg/esoutput/config.go
+++ b/pkg/esoutput/config.go
@@ -36,6 +36,7 @@ import (
 
 const (
 	defaultFlushPeriod = time.Second
+	defaultIndexName   = "k6-metrics"
 )
 
 type Config struct {
@@ -50,6 +51,7 @@ type Config struct {
 	ServiceAccountToken null.String `json:"serviceAccountToken" envconfig:"K6_ELASTICSEARCH_SERVICE_ACCOUNT_TOKEN"`
 
 	FlushPeriod types.NullDuration `json:"flushPeriod" envconfig:"K6_ELASTICSEARCH_FLUSH_PERIOD"`
+	IndexName   null.String        `json:"indexName" envconfig:"K6_ELASTICSEARCH_INDEX_NAME"`
 }
 
 func NewConfig() Config {
@@ -63,6 +65,7 @@ func NewConfig() Config {
 		Password:            null.NewString("", false),
 		ServiceAccountToken: null.NewString("", false),
 		FlushPeriod:         types.NullDurationFrom(defaultFlushPeriod),
+		IndexName:           null.StringFrom(defaultIndexName),
 	}
 }
 
@@ -100,6 +103,9 @@ func (base Config) Apply(applied Config) Config {
 
 	if applied.FlushPeriod.Valid {
 		base.FlushPeriod = applied.FlushPeriod
+	}
+	if applied.IndexName.Valid {
+		base.IndexName = applied.IndexName
 	}
 
 	return base
@@ -147,6 +153,9 @@ func ParseArg(arg string) (Config, error) {
 		if err := c.FlushPeriod.UnmarshalText([]byte(v)); err != nil {
 			return c, err
 		}
+	}
+	if v, ok := params["indexName"].(string); ok {
+		c.IndexName = null.StringFrom(v)
 	}
 
 	return c, nil
@@ -214,6 +223,9 @@ func GetConsolidatedConfig(jsonRawConf json.RawMessage, env map[string]string, a
 	}
 	if serviceAccountToken, defined := env["K6_ELASTICSEARCH_SERVICE_ACCOUNT_TOKEN"]; defined {
 		result.ServiceAccountToken = null.StringFrom(serviceAccountToken)
+	}
+	if indexName, defined := env["K6_ELASTICSEARCH_INDEX_NAME"]; defined {
+		result.IndexName = null.StringFrom(indexName)
 	}
 
 	if arg != "" {


### PR DESCRIPTION
With this commit we introduce a new environment variable `K6_ELASTICSEARCH_INDEX_NAME` that can be used to customize the name of the index that k6 uses to write metrics to. If unspecified, the default value stays `k6-metrics`.

Closes #17