### PR TITLE
Add datastream support

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,16 @@ export K6_ELASTICSEARCH_INSECURE_SKIP_VERIFY=true
 
 The metrics are stored in the index `k6-metrics` by default which will be automatically created by this extension. See the [mapping](pkg/esoutput/mapping.json) for details. The index name can be customized with the environment variable `K6_ELASTICSEARCH_INDEX_NAME`.
 
+### Writing to a datastream
+
+In addition to the normal setup, using Elasticsearch data streams require an op_type of `create`, which can be configured with `K6_ELASTICSEARCH_OP_TYPE`.
+
+```shell
+export K6_ELASTICSEARCH_OP_TYPE=create
+```
+
+There also has to exist a data stream enabled index template on the elasticsearch being written to. [Elasticsearch docs: Set up a data stream](https://www.elastic.co/guide/en/elasticsearch/reference/current/set-up-a-data-stream.html)
+
 ## Docker Compose
 
 This repo includes a [docker-compose.yml](./docker-compose.yml) file based on the [documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#docker-file), that starts Elasticsearch and Kibana. It also adds a custom build of k6 having the `xk6-output-elasticsearch` extension. This is just a quick way to showcase the usage, not meant for production usage.

--- a/pkg/esoutput/config.go
+++ b/pkg/esoutput/config.go
@@ -37,6 +37,7 @@ import (
 const (
 	defaultFlushPeriod = time.Second
 	defaultIndexName   = "k6-metrics"
+	defaultOpType      = "index"
 )
 
 type Config struct {
@@ -52,6 +53,7 @@ type Config struct {
 
 	FlushPeriod types.NullDuration `json:"flushPeriod" envconfig:"K6_ELASTICSEARCH_FLUSH_PERIOD"`
 	IndexName   null.String        `json:"indexName" envconfig:"K6_ELASTICSEARCH_INDEX_NAME"`
+	OpType      null.String        `json:"opType" envconfig:"K6_ELASTICSEARCH_OP_TYPE"`
 }
 
 func NewConfig() Config {
@@ -66,6 +68,7 @@ func NewConfig() Config {
 		ServiceAccountToken: null.NewString("", false),
 		FlushPeriod:         types.NullDurationFrom(defaultFlushPeriod),
 		IndexName:           null.StringFrom(defaultIndexName),
+		OpType:              null.StringFrom(defaultOpType),
 	}
 }
 
@@ -106,6 +109,9 @@ func (base Config) Apply(applied Config) Config {
 	}
 	if applied.IndexName.Valid {
 		base.IndexName = applied.IndexName
+	}
+	if applied.OpType.Valid {
+		base.OpType = applied.OpType
 	}
 
 	return base
@@ -156,6 +162,9 @@ func ParseArg(arg string) (Config, error) {
 	}
 	if v, ok := params["indexName"].(string); ok {
 		c.IndexName = null.StringFrom(v)
+	}
+	if v, ok := params["opType"].(string); ok {
+		c.OpType = null.StringFrom(v)
 	}
 
 	return c, nil
@@ -226,6 +235,9 @@ func GetConsolidatedConfig(jsonRawConf json.RawMessage, env map[string]string, a
 	}
 	if indexName, defined := env["K6_ELASTICSEARCH_INDEX_NAME"]; defined {
 		result.IndexName = null.StringFrom(indexName)
+	}
+	if opType, defined := env["K6_ELASTICSEARCH_OP_TYPE"]; defined {
+		result.OpType = null.StringFrom(opType)
 	}
 
 	if arg != "" {

--- a/pkg/esoutput/esoutput.go
+++ b/pkg/esoutput/esoutput.go
@@ -50,6 +50,7 @@ type elasticMetricEntry struct {
 	Value      float64
 	Tags       map[string]string
 	Time       time.Time
+	Timestamp  time.Time `json:"@timestamp"`
 }
 
 type Output struct {
@@ -228,13 +229,14 @@ func (o *Output) flush() {
 				Value:      sample.Value,
 				Tags:       sample.GetTags().Map(),
 				Time:       sample.Time,
+				Timestamp:  sample.Time,
 			}
 			data, err := json.Marshal(mappedEntry)
 			if err != nil {
 				o.logger.Fatalf("Cannot encode document: %s, %s", err, mappedEntry)
 			}
 			var item = esutil.BulkIndexerItem{
-				Action:    "index",
+				Action:    o.config.OpType.String,
 				Body:      bytes.NewReader(data),
 				OnFailure: o.blkItemErrHandler,
 			}

--- a/pkg/esoutput/mapping.json
+++ b/pkg/esoutput/mapping.json
@@ -19,6 +19,9 @@
             "enabled": true
         },
         "properties": {
+            "@timestamp": {
+                "type": "date"
+            },
             "Time": {
                 "type": "date"
             },


### PR DESCRIPTION
* Make "Action" of the bulk API call configurable (but defaulting to previous hardcoded value)
* Add @timestamp field

Metrics in modern elasticsearch use data streams (and potentially Time series Data streams) for easier management (and better compression with TSDS). This requires an "Action" or `op_type` in the `_bulk` request to be `create`.

Data streams also require a `@timestamp` field, although this can be added with an ingest pipeline and is not strictly necessary to add here - could be removed from code and replace with documentation.