### PR TITLE
Use 'create' action for bulk

### DIFF
--- a/pkg/esoutput/esoutput.go
+++ b/pkg/esoutput/esoutput.go
@@ -234,7 +234,7 @@ func (o *Output) flush() {
 				o.logger.Fatalf("Cannot encode document: %s, %s", err, mappedEntry)
 			}
 			var item = esutil.BulkIndexerItem{
-				Action:    "index",
+				Action:    "create",
 				Body:      bytes.NewReader(data),
 				OnFailure: o.blkItemErrHandler,
 			}


### PR DESCRIPTION
With this commit we change the bulk action from `index` to `create`. As we only ever add new documents to the index, there is no need to use the more generic `index`. This allows users to use also datastreams instead of plain indices to store k6 metrics.

Relates #30